### PR TITLE
Change GoHome to use `/lifestream auto`

### DIFF
--- a/Automaton/Features/ARTurnIn.cs
+++ b/Automaton/Features/ARTurnIn.cs
@@ -113,7 +113,7 @@ internal class ARTurnIn : Tweak<ARTurnInConfiguration>
     // bless lifestream for doing literally all the annoying work for me already
     private void GoToGC() => TaskManager.InsertMulti([new(() => P.Lifestream.ExecuteCommand("gc")), new(() => P.Lifestream.IsBusy()), new(() => !P.Lifestream.IsBusy(), LSConfig)]);
     private void Deliveroo() => TaskManager.InsertMulti([new(() => Svc.Commands.ProcessCommand("/deliveroo enable")), new(() => P.Deliveroo.IsTurnInRunning()), new(() => !P.Deliveroo.IsTurnInRunning(), DConfig)]);
-    private void GoHome() => TaskManager.InsertMulti([new(P.Lifestream.TeleportToFC), new(() => P.Lifestream.IsBusy()), new(() => !P.Lifestream.IsBusy(), LSConfig)]);
+    private void GoHome() => TaskManager.InsertMulti([new(() => P.Lifestream.ExecuteCommand("auto")), new(() => P.Lifestream.IsBusy()), new(() => !P.Lifestream.IsBusy(), LSConfig)]);
 
     private TaskManagerConfiguration LSConfig => new(timeLimitMS: 2 * 60 * 1000);
     private TaskManagerConfiguration DConfig => new(timeLimitMS: 10 * 60 * 1000, abortOnTimeout: false);


### PR DESCRIPTION
Current Problem:
 AutoRetainer x Deliveroo feature is hardcoded to go to your FC house, though there are reasons that this may not be desirable or even possible.

**Describe the solution you'd like**
Relying on `/lifestream auto` to have a user-configurable priority would allow for everyone to choose where they go,  across multiple characters with different FC statuses.

**Describe alternatives you've considered**
An alternative could be to build out destination options inside of the AutoRetainer x Deliveroo feature, though using the auto feature in Lifestream seems a lot simpler and keeps things nicely separated by using existing options.

**Additional context**
I have used this frequently over the past several weeks to navigate to the Maelstrom GC, then to the Limsa Inn, without issue.

Photo showing the option's location inside of Lifestream
![ffxiv_dx11_LY0cTEWXtv](https://github.com/user-attachments/assets/85727a3a-858d-440a-8456-9b50eb08bab2)
