### PR TITLE
Fix for AutoFollowName not being respected

### DIFF
--- a/Automaton/Features/AutoFollow.cs
+++ b/Automaton/Features/AutoFollow.cs
@@ -82,7 +82,7 @@ public unsafe class AutoFollow : Tweak<AutoFollowConfiguration>
 
     private void Follow(IFramework framework)
     {
-        if (master == null || !Player.Available || TaskManager.IsBusy) return;
+        if (master == null && Config.AutoFollowName.IsNullOrEmpty() || !Player.Available || TaskManager.IsBusy) return;
 
         master = Svc.Objects.FirstOrDefault(x => x.EntityId == masterObjectID || !Config.AutoFollowName.IsNullOrEmpty() && x.Name.TextValue.Equals(Config.AutoFollowName, StringComparison.InvariantCultureIgnoreCase));
 


### PR DESCRIPTION
Current implementation of AutoFollowName Config is being ignored.

Modified the first return condition to only trigger when both master is null and AutoFollowName is not configured.
Allows for configured Name to be searched and applied master when found as intended. 