### PR TITLE
Allow more than 50 chars in string fields

### DIFF
--- a/Automaton/FeaturesSetup/Attributes/Config/StringConfigAttribute.cs
+++ b/Automaton/FeaturesSetup/Attributes/Config/StringConfigAttribute.cs
@@ -19,7 +19,7 @@ public class StringConfigAttribute : BaseConfigAttribute
 
         ImGui.TextUnformatted(fieldInfo.Name.SplitWords());
 
-        if (ImGui.InputText("##Input", ref value, 50))
+        if (ImGui.InputText("##Input", ref value, 200))
         {
             fieldInfo.SetValue(config, value);
             OnChangeInternal(tweak, fieldInfo);


### PR DESCRIPTION
This is specially for AutoInvite Regex, but will change everything else