### PR TITLE
Bug Fix - Prevent continued movement after disabling AutoFollow

### DIFF
--- a/Automaton/Features/AutoFollow.cs
+++ b/Automaton/Features/AutoFollow.cs
@@ -92,13 +92,14 @@ public unsafe class AutoFollow : Tweak<AutoFollowConfiguration>
     {
         _masterId = null;
         _masterName = null;
+        movement.Enabled = false;
         Svc.Toasts.ShowNormal("Auto following off");
     }
 
     private void Follow(IFramework framework)
     {
         if (!Player.Available || TaskManager.IsBusy) return;
-        if (_masterId == null && Config.AutoFollowName.IsNullOrEmpty() && string.IsNullOrEmpty(_masterName)) { movement.Enabled = false; return; } // always try to follow if temp or permanent name is set
+        if (_masterId == null && Config.AutoFollowName.IsNullOrEmpty() && string.IsNullOrEmpty(_masterName)) return; // always try to follow if temp or permanent name is set
 
         var master = Svc.Objects.FirstOrDefault(x => x.EntityId == _masterId
             || (!Config.AutoFollowName.IsNullOrEmpty() && x.Name.TextValue.Equals(Config.AutoFollowName, StringComparison.InvariantCultureIgnoreCase))

--- a/Automaton/Features/AutoFollow.cs
+++ b/Automaton/Features/AutoFollow.cs
@@ -98,7 +98,7 @@ public unsafe class AutoFollow : Tweak<AutoFollowConfiguration>
     private void Follow(IFramework framework)
     {
         if (!Player.Available || TaskManager.IsBusy) return;
-        if (_masterId == null && Config.AutoFollowName.IsNullOrEmpty() && string.IsNullOrEmpty(_masterName)) return; // always try to follow if temp or permanent name is set
+        if (_masterId == null && Config.AutoFollowName.IsNullOrEmpty() && string.IsNullOrEmpty(_masterName)) { movement.Enabled = false; return; } // always try to follow if temp or permanent name is set
 
         var master = Svc.Objects.FirstOrDefault(x => x.EntityId == _masterId
             || (!Config.AutoFollowName.IsNullOrEmpty() && x.Name.TextValue.Equals(Config.AutoFollowName, StringComparison.InvariantCultureIgnoreCase))


### PR DESCRIPTION
Going to annoy you one last time for awhile lol

When AutoFollow is disabled while your character is moving, they will continue heading toward the last set position of the previous follow target. This change stops that behavior so movement halts properly when master is no longer set.